### PR TITLE
Refactor chunker model and add system overview

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,81 @@
+# Holoplan CLI — System Overview
+
+**Holoplan CLI** is a deterministic, multi-agent CLI tool that transforms plain user stories into complete Draw.io wireframes via local LLMs. It uses a modular pipeline of structured reasoning and validation to create production-ready UI blueprints.
+
+---
+
+## Pipeline Stages
+
+Each user story flows through the following stages:
+
+1. **Chunk** → Breaks a story into discrete UI views.
+2. **Build** → Generates a Draw.io-compatible XML layout for each view.
+3. **Validate** → Analyzes layout geometry for visual and semantic flaws.
+4. **Audit** → Optionally critiques the layout for completeness or conformance to UX guidelines.
+
+---
+
+## StoryChunker (chunker.go)
+
+- **Input**: Natural-language user story (e.g., "As a visitor, I want to view adoptable dogs.")
+- **Output**: `ViewPlan` object containing:
+  - A list of named views (e.g., `View Adoptable Dogs List`)
+  - A reasoning string explaining the decomposition
+- **LLM Used**: `huihui_ai/Hermes-3-Llama-3.2-abliterated:3b-q8_0`
+- **Robustness**: Strips out `<think>` and extraneous LLM formatting to recover raw JSON
+
+---
+
+## Layout Builder (builder.go)
+
+- **Input**: Each view definition (`ViewLayout`) from the chunking stage
+- **Output**: XML layout (Draw.io-compatible) using defined view name and type
+- **Key Design**: Uses consistent spatial rules for component placement
+
+---
+
+## Layout Validator (validator/layout.go)
+
+Ensures spatial and semantic layout integrity before export.
+
+### Validation Rules
+
+1. **Collision Detection**  
+   Ensures UI elements do not visually overlap (`checkCollisions`)
+
+2. **Vertical Flow Order**  
+   Verifies that elements follow a top-down reading order (`checkVerticalFlow`)
+
+3. **Semantic Zone Conformance**  
+   Ensures that common UI elements appear in conventional areas:
+   - `nav` elements near the top
+   - `modal` elements in the center
+   - `footer` elements near the bottom  
+   (`checkSemanticZones`)
+
+### Technical Details
+
+- Parses `mxGraphModel` XML used by Draw.io
+- Extracts visible elements (`vertex="1"`)
+- Coordinates (x, y, width, height) are used to enforce geometry
+
+---
+
+## File Structure Summary
+
+| File/Dir | Purpose |
+|----------|---------|
+| `src/main.go` | Entry point and orchestration |
+| `src/agents/` | Chunker and builder logic |
+| `src/validator/` | Geometry-based layout rules |
+| `examples/user_stories.yaml` | Input story corpus |
+| `docs/overview.md` | System documentation |
+
+---
+
+## CLI Usage
+
+```bash
+go run src/main.go --stories examples/user_stories.yaml
+````
+

--- a/src/agents/auditor.go
+++ b/src/agents/auditor.go
@@ -58,7 +58,7 @@ func extractIssues(text string) []string {
 
 func callOllama(prompt string) (string, error) {
 	body := map[string]string{
-		"model":  "llama3", // or whichever model is running
+		"model":  "llama3.1:8b", // or whichever model is running
 		"prompt": prompt,
 	}
 	b, _ := json.Marshal(body)

--- a/src/agents/chunker.go
+++ b/src/agents/chunker.go
@@ -5,15 +5,36 @@ import (
 	"encoding/json"
 	"fmt"
 	"holoplan-cli/src/types"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"regexp"
+	"strings"
 )
 
 const ollamaURL = "http://localhost:11434/api/chat"
 
+// Remove <think>...</think> and extract JSON block only
+func extractCleanJSON(raw string) string {
+	// Remove all <think>...</think> blocks
+	reThink := regexp.MustCompile(`(?s)<think>.*?</think>`)
+	cleaned := reThink.ReplaceAllString(raw, "")
+
+	// Trim whitespace
+	cleaned = strings.TrimSpace(cleaned)
+
+	// Try to extract first valid JSON block
+	start := strings.Index(cleaned, "{")
+	end := strings.LastIndex(cleaned, "}")
+	if start == -1 || end == -1 || start > end {
+		return cleaned // fallback: return raw
+	}
+
+	return cleaned[start : end+1]
+}
+
 func Chunk(story types.UserStory) types.ViewPlan {
 	payload := map[string]interface{}{
-		"model":       "deepcoder:14b-preview-q4_K_M",
+		"model":       "huihui_ai/Hermes-3-Llama-3.2-abliterated:3b-q8_0",
 		"stream":      false,
 		"temperature": 0,
 		"seed":        42,
@@ -29,21 +50,22 @@ func Chunk(story types.UserStory) types.ViewPlan {
 		},
 	}
 
-	// Marshal payload
 	data, err := json.Marshal(payload)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("failed to marshal request payload: %w", err))
 	}
 
 	resp, err := http.Post(ollamaURL, "application/json", bytes.NewBuffer(data))
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("failed to call Ollama API: %w", err))
 	}
 	defer resp.Body.Close()
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		panic(fmt.Errorf("failed to read response: %w", err))
+	}
 
-	// Parse LLM output
 	var parsed struct {
 		Message struct {
 			Content string `json:"content"`
@@ -51,16 +73,17 @@ func Chunk(story types.UserStory) types.ViewPlan {
 	}
 	err = json.Unmarshal(body, &parsed)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("failed to unmarshal Ollama response: %w", err))
 	}
 
-	// Extract JSON from message content
+	cleaned := extractCleanJSON(parsed.Message.Content)
+
 	var plan types.ViewPlan
-	err = json.Unmarshal([]byte(parsed.Message.Content), &plan)
+	err = json.Unmarshal([]byte(cleaned), &plan)
 	if err != nil {
 		fmt.Println("🛑 Could not parse LLM output:")
 		fmt.Println(parsed.Message.Content)
-		panic(err)
+		panic(fmt.Errorf("JSON parse error: %w", err))
 	}
 
 	plan.StoryID = story.ID


### PR DESCRIPTION
This PR updates the `chunker.go` logic to use the new `Hermes-3-Llama-3.2-abliterated:3b-q8_0` model and strips out invalid JSON artifacts like `<think>` tags. It also introduces `docs/overview.md`, which provides a high-level walkthrough of the pipeline, layout validation logic, and component responsibilities.