### PR TITLE
Add Makefile, script, and error handling improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+# Makefile
+
+.PHONY: wireframes empty
+
+wireframes:
+	go run src/main.go --stories examples/user_stories.yaml
+
+empty:
+	./scripts/empty_output.sh

--- a/scripts/empty_output.sh
+++ b/scripts/empty_output.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# scripts/empty_output.sh
+
+echo "🧹 Deleting all .drawio.xml files in the output directory..."
+rm -f output/*.drawio.xml
+echo "✅ output directory cleaned."

--- a/src/prompts/builder_prompt.txt
+++ b/src/prompts/builder_prompt.txt
@@ -1,0 +1,14 @@
+You are a senior UI architect. Output a valid Draw.io layout for the following view.
+
+View Name: {{view_name}}
+View Type: {{view_type}}
+Components: {{components}}
+
+Instructions:
+- Output must be ONLY Draw.io XML.
+- Do not include markdown, explanation, or code comments.
+- Begin output with <mxGraphModel> and include a <root> with nested <mxCell> elements.
+- Each component should be represented as a rectangle, clearly labeled.
+- Position components logically on a 2D plane.
+
+Your output will be parsed and validated automatically. Any extra text will cause a failure.

--- a/src/shared/xml.go
+++ b/src/shared/xml.go
@@ -1,12 +1,34 @@
+// src/shared/xml.go
 package shared
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
-// ExtractXMLFrom trims off any LLM commentary and returns just the XML.
+// ExtractXMLFrom trims LLM commentary and returns just the <mxGraphModel> XML.
 func ExtractXMLFrom(response string) string {
-	start := strings.Index(response, "<")
-	if start == -1 {
-		return response
+	// Clean up any markdown code blocks
+	cleaned := strings.ReplaceAll(response, "```xml", "")
+	cleaned = strings.ReplaceAll(cleaned, "```", "")
+	cleaned = strings.TrimSpace(cleaned)
+
+	// Remove <think> blocks completely
+	cleaned = regexp.MustCompile(`(?s)<think>.*?</think>`).ReplaceAllString(cleaned, "")
+	cleaned = strings.TrimSpace(cleaned)
+
+	// Look for actual <mxGraphModel> content
+	re := regexp.MustCompile(`(?s)<mxGraphModel>.*?</mxGraphModel>`)
+	match := re.FindString(cleaned)
+	if match != "" {
+		return match
 	}
-	return response[start:]
+
+	// Fallback: if XML starts somewhere, try returning from first XML tag
+	start := strings.Index(cleaned, "<mxGraphModel")
+	if start != -1 {
+		return cleaned[start:]
+	}
+
+	return ""
 }


### PR DESCRIPTION
### Summary

- Added a `Makefile` with `make wireframes` and `make empty` targets for convenience.
- Created `scripts/empty_output.sh` to clean the `output/` directory.
- Switched models in both `chunker.go` and `builder.go` to Qwen/Hermes.
- Improved error handling and added visibility into prompt construction and response issues.

These changes improve reliability of layout generation and streamline local development.