### PR TITLE
Working pipeline: chunking and docs

### DIFF
--- a/docs/how_userstories_are_chunked.md
+++ b/docs/how_userstories_are_chunked.md
@@ -1,0 +1,105 @@
+# How User Stories Are Chunked
+
+This document describes how Holoplan processes user stories and transforms them into structured UI view plans using a dedicated LLM agent (`chunker.go`).
+
+---
+
+## 📘 Overview
+
+Holoplan reads user stories from a YAML file and feeds them, one at a time, into a local LLM via the `Chunk()` agent. The LLM returns a structured JSON payload describing the UI views required to satisfy the story. Each view includes its name, type, and components.
+
+---
+
+## 🔄 Chunking Pipeline
+
+```mermaid
+flowchart TD
+    A[Start: Load YAML File]
+    B[Parse into array of UserStory structs]
+    C[Loop through each UserStory]
+    D[Send narrative to Chunk Agent]
+    E[Chunk Agent calls local LLM with system + user prompt]
+    F[LLM returns JSON object with views and reasoning]
+    G[Clean JSON via extractCleanJSON]
+    H[Parse into ViewPlan struct]
+    I[Assign story ID to ViewPlan]
+    J[Return ViewPlan to main loop]
+
+    A --> B --> C --> D --> E --> F --> G --> H --> I --> J
+```
+
+# Chunk Agent Interaction: Sequence Diagram
+
+This diagram shows the step-by-step sequence of how the Holoplan system interacts with the `Chunk` agent and the local LLM to transform a user story into structured views.
+
+```mermaid
+sequenceDiagram
+    participant CLI as holoplan-cli
+    participant YAML as user_stories.yaml
+    participant CHUNKER as chunker.go
+    participant LLM as local LLM (Ollama)
+    participant JSON as extractCleanJSON()
+    participant VIEW as ViewPlan Parser
+
+    CLI->>YAML: Read YAML into []UserStory
+    CLI->>CHUNKER: Send one UserStory to Chunk()
+    CHUNKER->>LLM: Send prompt with story.narrative
+    LLM-->>CHUNKER: Return raw JSON + optional reasoning
+    CHUNKER->>JSON: Sanitize and extract valid JSON
+    JSON-->>CHUNKER: Cleaned JSON string
+    CHUNKER->>VIEW: Parse into ViewPlan struct
+    VIEW-->>CHUNKER: ViewPlan with views + metadata
+    CHUNKER-->>CLI: Return structured ViewPlan
+```
+---
+
+## 🔍 Example
+
+**Input YAML:**
+
+```yaml
+- id: "US-101"
+  title: "Browse Indoor Plants"
+  narrative: |
+    As a plant enthusiast,
+    I want to browse a list of indoor plants,
+    so that I can choose one that suits my home environment.
+```
+
+**LLM Prompt:**
+
+```text
+User story:
+As a plant enthusiast,
+I want to browse a list of indoor plants,
+so that I can choose one that suits my home environment.
+```
+
+**Expected JSON Response:**
+
+```json
+{
+  "views": [
+    {
+      "name": "Plant Gallery",
+      "type": "GridView",
+      "components": ["Plant Image", "Plant Name", "Lighting Icon", "Add to Favorites"]
+    }
+  ],
+  "reasoning": "The story is about browsing a list of plants, so a grid-based gallery with key details is appropriate."
+}
+```
+
+---
+
+## 🧠 Agent Logic Summary
+
+* Uses temperature 0 and deterministic seed
+* Extracts raw JSON from noisy LLM outputs using `extractCleanJSON()`
+* Escapes embedded newlines and trims `<think>` tags
+* Logs view extraction and errors for traceability
+
+---
+
+
+

--- a/examples/user_stories_2.yaml
+++ b/examples/user_stories_2.yaml
@@ -1,0 +1,34 @@
+- id: "US-101"
+  title: "Browse Indoor Plants"
+  narrative: |
+    As a plant enthusiast,
+    I want to browse a list of indoor plants,
+    so that I can choose one that suits my home environment.
+
+- id: "US-102"
+  title: "View Plant Details"
+  narrative: |
+    As a shopper,
+    I want to click on a plant card,
+    so that I can read more about its care instructions and price.
+
+- id: "US-103"
+  title: "Add Plant to Cart"
+  narrative: |
+    As a customer,
+    I want to add a plant to my shopping cart,
+    so that I can purchase it later after reviewing other options.
+
+- id: "US-104"
+  title: "Checkout with Delivery Options"
+  narrative: |
+    As a user,
+    I want to choose delivery or in-store pickup during checkout,
+    so that I can receive my plant in the most convenient way.
+
+- id: "US-105"
+  title: "Track My Order"
+  narrative: |
+    As a buyer,
+    I want to track the shipping status of my plant order,
+    so that I know when it will arrive.

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module holoplan-cli
 go 1.24.2
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require github.com/beevik/etree v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/beevik/etree v1.5.1 h1:TC3zyxYp+81wAmbsi8SWUpZCurbxa6S8RITYRSkNRwo=
+github.com/beevik/etree v1.5.1/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/scripts/empty_output.sh
+++ b/scripts/empty_output.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 OUTPUT_DIR="output"
 
-echo "Deleting all .drawio.xml files in the '$OUTPUT_DIR' directory..."
+echo "Deleting all .drawio files in the '$OUTPUT_DIR' directory..."
 
 if [ ! -d "$OUTPUT_DIR" ]; then
   echo "Directory '$OUTPUT_DIR' does not exist. Nothing to clean."
@@ -13,7 +13,7 @@ if [ ! -d "$OUTPUT_DIR" ]; then
 fi
 
 shopt -s nullglob
-FILES=("$OUTPUT_DIR"/*.drawio.xml)
+FILES=("$OUTPUT_DIR"/*.drawio)
 shopt -u nullglob
 
 if [ ${#FILES[@]} -eq 0 ]; then

--- a/src/agents/builder.go
+++ b/src/agents/builder.go
@@ -54,7 +54,7 @@ func Build(view types.ViewLayout) string {
 // callOllamaForLayout streams a completion from Ollama and returns the full text.
 func callOllamaForLayout(prompt string) (string, error) {
 	body := map[string]interface{}{
-		"model":  "qwen2.5-coder:14b-instruct-q5_K_M", // or "qwen3:latest"
+		"model":  "qwen2.5-coder:7b-instruct-q6_K", // or "qwen3:latest"
 		"prompt": prompt,
 		"stream": true,
 	}

--- a/src/agents/builder.go
+++ b/src/agents/builder.go
@@ -27,7 +27,7 @@ func Build(view types.ViewLayout) string {
 	prompt = strings.ReplaceAll(prompt, "{{components}}", strings.Join(view.Components, ", "))
 
 	// 🔍 Print the final prompt before sending it to the LLM
-	fmt.Printf("📤 Prompt for view '%s':\n%s\n", view.Name, prompt)
+	// fmt.Printf("📤 Prompt for view '%s':\n%s\n", view.Name, prompt)
 
 	response, err := callOllamaForLayout(prompt)
 	if err != nil {
@@ -54,7 +54,7 @@ func Build(view types.ViewLayout) string {
 // callOllamaForLayout streams a completion from Ollama and returns the full text.
 func callOllamaForLayout(prompt string) (string, error) {
 	body := map[string]interface{}{
-		"model":  "qwen:7b", // or "qwen3:latest"
+		"model":  "qwen2.5-coder:14b-instruct-q5_K_M", // or "qwen3:latest"
 		"prompt": prompt,
 		"stream": true,
 	}
@@ -78,8 +78,10 @@ func callOllamaForLayout(prompt string) (string, error) {
 			Done     bool   `json:"done"`
 		}
 		if err := decoder.Decode(&chunk); err != nil {
-			break // EOF or malformed
+			fmt.Printf("🛑 Streaming decode failed: %v\n", err)
+			break
 		}
+
 		fullResponse.WriteString(chunk.Response)
 		if chunk.Done {
 			break

--- a/src/main.go
+++ b/src/main.go
@@ -1,3 +1,4 @@
+// src\main.go
 package main
 
 import (
@@ -99,7 +100,7 @@ func main() {
 		}
 	}
 
-	err = MergeDrawio("output/final.drawio.xml")
+	err = MergeDrawio("output/final.drawio")
 	if err != nil {
 		log.Fatalf("Merge failed: %v", err)
 	}
@@ -136,7 +137,7 @@ func SaveOutput(viewName string, xml string, critique types.Critique) error {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	xmlPath := filepath.Join("output", viewName+".drawio.xml")
+	xmlPath := filepath.Join("output", viewName+".drawio")
 	if err := os.WriteFile(xmlPath, []byte(xml), 0644); err != nil {
 		return fmt.Errorf("failed to write XML: %w", err)
 	}
@@ -156,7 +157,7 @@ func SaveOutput(viewName string, xml string, critique types.Critique) error {
 }
 
 func MergeDrawio(outputPath string) error {
-	files, err := filepath.Glob("output/*.drawio.xml")
+	files, err := filepath.Glob("output/*.drawio")
 	if err != nil {
 		return fmt.Errorf("failed to scan output files: %w", err)
 	}

--- a/src/prompts/builder_prompt.txt
+++ b/src/prompts/builder_prompt.txt
@@ -1,14 +1,48 @@
-You are a senior UI architect. Output a valid Draw.io layout for the following view.
+You are a Draw.io layout generator. Given a user interface view, output **only valid Draw.io XML**.
 
-View Name: {{view_name}}
-View Type: {{view_type}}
+View Name: {{view_name}}  
+View Type: {{view_type}}  
 Components: {{components}}
 
 Instructions:
-- Output must be ONLY Draw.io XML.
-- Do not include markdown, explanation, or code comments.
-- Begin output with <mxGraphModel> and include a <root> with nested <mxCell> elements.
-- Each component should be represented as a rectangle, clearly labeled.
-- Position components logically on a 2D plane.
+- Output must begin with <mxGraphModel> and include a single <root> element.
+- The root must contain only properly formed <mxCell> elements.
+- Do NOT include markdown, explanations, comments, or <think> tags.
+- Each component must be represented as a <mxCell> with:
+  - A unique id (e.g., id="3", id="4", etc.)
+  - vertex="1"
+  - parent="1"
+  - A value attribute equal to the component's label
+  - Exactly one <mxGeometry> child with properly quoted attributes:
+    Example:
+    <mxCell id="3" value="Submit Button" style="rounded=1;whiteSpace=wrap;fillColor=&quot;#aed581&quot;" vertex="1" parent="1">
+      <mxGeometry x="100" y="200" width="600" height="50" as="geometry"/>
+    </mxCell>
 
-Your output will be parsed and validated automatically. Any extra text will cause a failure.
+Structural Requirements:
+- You must include:
+  - <mxCell id="0"/> — the root container
+  - <mxCell id="1" parent="0"/> — the main canvas container
+- All other cells must be children of <root> with parent="1"
+- Each <mxCell> must not contain any other <mxCell> as a child
+- <mxGeometry> is the only valid child of <mxCell>
+- All attribute values in XML must be enclosed in double quotes
+
+Layout Notes:
+- Begin layout at y="100" and use consistent vertical spacing (e.g., 60px increments)
+- Place nav bars or headers above the components if applicable
+- Use logical spatial positioning without overlaps
+- You may use styling attributes like:
+  - rounded=1
+  - whiteSpace=wrap
+  - fillColor="#f5f5f5" for neutral containers
+  - fillColor="#aed581" for buttons or CTAs
+
+Compliance Checklist:
+✅ All XML must be well-formed  
+✅ All attributes quoted (e.g., width="600")  
+✅ No nested <mxCell> elements  
+✅ Each <mxCell> has one <mxGeometry>  
+✅ Output contains XML only — no text, logs, or comments  
+
+Any violation of these rules will result in invalid output that cannot be parsed or rendered.


### PR DESCRIPTION
This PR introduces:

- A second set of example user stories (`user_stories_2.yaml`) to test domain generality.
- A complete markdown doc explaining how user stories are chunked into view plans, including diagrams.
- Full support for narrative-to-layout pipeline from parsing to validation.

Tested locally using both example YAML files. Layout generation and critique pipeline verified to work.