### PR TITLE
Changed run command behaviour

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -2,8 +2,10 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"holoplan-cli/src/runner"
 
@@ -23,14 +25,22 @@ func main() {
 		Short: "Generate wireframes from a YAML file of user stories",
 		Run: func(cmd *cobra.Command, args []string) {
 			if storiesPath == "" {
-				fmt.Println("❌ Please provide a path to the YAML file using --stories")
-				os.Exit(1)
+				fmt.Print("Please provide a filepath for the user stories.yaml: ")
+				reader := bufio.NewReader(os.Stdin)
+				input, err := reader.ReadString('\n')
+				if err != nil {
+					fmt.Println("[x] Failed to read input:", err)
+					os.Exit(1)
+				}
+				storiesPath = strings.TrimSpace(input)
 			}
+
 			if err := runner.RunPipeline(storiesPath); err != nil {
-				fmt.Printf("🚨 Pipeline failed: %v\n", err)
+				fmt.Println("[x] Pipeline failed:", err)
 				os.Exit(1)
 			}
-			fmt.Println("🎉 All done!")
+
+			fmt.Println("[✓] Pipeline completed successfully")
 		},
 	}
 
@@ -38,7 +48,7 @@ func main() {
 	rootCmd.AddCommand(runCmd)
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Println("[x] Command execution failed:", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Prompt for user stories path if not provided


This PR updates the `run` command behavior to prompt the user interactively for a `user stories.yaml` filepath if the `--stories` flag is not provided.


## Changes

- Uses `bufio.NewReader` to safely read input with spaces.
- Replaces emoji output with `[x]` for errors and `[✓]` for success.
- Keeps full support for `--stories` and `-s` flags for non-interactive use.

This makes the CLI more user-friendly for manual runs.