### PR TITLE
Refactor: model control & prompt tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - 📖 **YAML-based User Story Input**
 - 🧠 **LLM-based Story Chunking**
-- 🏗 **Hermes Model Layout Builder**
+- 🏗 **Qwen2.5 Coder Model Layout Builder**
 - 🔍 **Automated UI Critique + Correction Loop**
 - 📏 **Go-based Spatial Validation**
 - 🧾 **Draw.io XML Output + Critique Logs**

--- a/scripts/empty_output.sh
+++ b/scripts/empty_output.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 OUTPUT_DIR="output"
 
-echo "Deleting all .drawio files in the '$OUTPUT_DIR' directory..."
+echo "Deleting all .drawio and .drawio.xml files in the '$OUTPUT_DIR' directory..."
 
 if [ ! -d "$OUTPUT_DIR" ]; then
   echo "Directory '$OUTPUT_DIR' does not exist. Nothing to clean."
@@ -13,11 +13,11 @@ if [ ! -d "$OUTPUT_DIR" ]; then
 fi
 
 shopt -s nullglob
-FILES=("$OUTPUT_DIR"/*.drawio)
+FILES=("$OUTPUT_DIR"/*.drawio "$OUTPUT_DIR"/*.drawio.xml)
 shopt -u nullglob
 
 if [ ${#FILES[@]} -eq 0 ]; then
-  echo "No .drawio files to delete in '$OUTPUT_DIR'."
+  echo "No .drawio or .drawio.xml files to delete in '$OUTPUT_DIR'."
 else
   rm -f "${FILES[@]}"
   echo "Deleted ${#FILES[@]} file(s) from '$OUTPUT_DIR'."

--- a/src/agents/builder.go
+++ b/src/agents/builder.go
@@ -54,7 +54,7 @@ func Build(view types.ViewLayout) string {
 // callOllamaForLayout streams a completion from Ollama and returns the full text.
 func callOllamaForLayout(prompt string) (string, error) {
 	body := map[string]interface{}{
-		"model":  "qwen2.5-coder:3b-instruct-q8_0",
+		"model":  "qwen2.5-coder:7b-instruct-q6_K",
 		"prompt": prompt,
 		"stream": true,
 	}

--- a/src/agents/builder.go
+++ b/src/agents/builder.go
@@ -54,9 +54,9 @@ func Build(view types.ViewLayout) string {
 // callOllamaForLayout streams a completion from Ollama and returns the full text.
 func callOllamaForLayout(prompt string) (string, error) {
 	body := map[string]interface{}{
-		"model":  "qwen2.5-coder:7b-instruct-q6_K",
-		"prompt": prompt,
-		"stream": true,
+		"model":       "qwen2.5-coder:7b-instruct-q6_K",
+		"prompt":      prompt,
+		"temperature": 0.0,
 	}
 	b, err := json.Marshal(body)
 	if err != nil {

--- a/src/agents/chunker.go
+++ b/src/agents/chunker.go
@@ -51,7 +51,7 @@ func escapeLineBreaks(input string) string {
 // Chunk takes a UserStory and extracts views using the LLM.
 func Chunk(story types.UserStory) types.ViewPlan {
 	payload := map[string]interface{}{
-		"model":       "llama3.1:8b",
+		"model":       "qwen2.5-coder:3b-instruct-q8_0",
 		"stream":      false,
 		"temperature": 0,
 		"seed":        42,
@@ -106,7 +106,7 @@ func Chunk(story types.UserStory) types.ViewPlan {
 
 	// Debug Line: print the extracted JSON from the chunker
 	// fmt.Println("\n🔎 DEBUG: Cleaned JSON extracted from LLM response:")
-	fmt.Println(cleaned)
+	// fmt.Println(cleaned)
 
 	var plan types.ViewPlan
 	err = json.Unmarshal([]byte(cleaned), &plan)

--- a/src/prompts/builder_prompt.txt
+++ b/src/prompts/builder_prompt.txt
@@ -15,7 +15,7 @@ Instructions:
   - A value attribute equal to the component's label
   - Exactly one <mxGeometry> child with properly quoted attributes:
     Example:
-    <mxCell id="3" value="Submit Button" style="rounded=1;whiteSpace=wrap;fillColor=#aed581 vertex="1" parent="1">
+    <mxCell id="3" value="Submit Button" style="rounded=1;whiteSpace=wrap;fillColor=#aed581" vertex="1" parent="1">
       <mxGeometry x="100" y="200" width="600" height="50" as="geometry"/>
     </mxCell>
 
@@ -48,4 +48,5 @@ Compliance Checklist:
 
 !! Do NOT escape color values or quote them. Use: fillColor=#xxxxxx not fillColor=&quot;#xxxxxx&quot;
 !! Ensure that each component is placed far enough vertically so its full height does not overlap with the next. Use y = previous_y + previous_height + margin.
-!! Any violation of these rules will result in invalid output that cannot be parsed or rendered.
+!! Only output valid XML. All attribute values must be quoted.
+


### PR DESCRIPTION
This PR tweaks the builder prompt and sets `temperature: 0` for deterministic XML output. Also includes minor cleanup to `empty_output.sh`, disables a debug line in `chunker.go`, and updates the README accordingly.