### PR TITLE
Wrs/fix/over quoting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,6 @@ wireframes:
 
 empty:
 	./scripts/empty_output.sh
+
+install:
+	pwsh -ExecutionPolicy Bypass -File ./install.ps1

--- a/src/agents/resolver.go
+++ b/src/agents/resolver.go
@@ -1,3 +1,4 @@
+// src/agents/resolver.go
 package agents
 
 import (

--- a/src/prompts/builder_prompt.txt
+++ b/src/prompts/builder_prompt.txt
@@ -9,44 +9,56 @@ Instructions:
 - The root must contain only properly formed <mxCell> elements.
 - Do NOT include markdown, explanations, comments, or <think> tags.
 - Each component must be represented as a <mxCell> with:
-  - A unique id (e.g., id="3", id="4", etc.)
-  - vertex="1"
-  - parent="1"
-  - A value attribute equal to the component's label
-  - Exactly one <mxGeometry> child with properly quoted attributes:
-    Example:
+  - A unique `id`, quoted (e.g., id="3", id="4", etc.)
+  - `vertex="1"`
+  - `parent="1"`
+  - A `value` attribute quoted with the component’s label (e.g., value="Submit Button")
+  - Exactly one `<mxGeometry>` child with **all attributes quoted**:
+    ✅ Good:
+    ```xml
     <mxCell id="3" value="Submit Button" style="rounded=1;whiteSpace=wrap;fillColor=#aed581" vertex="1" parent="1">
       <mxGeometry x="100" y="200" width="600" height="50" as="geometry"/>
     </mxCell>
+    ```
+
+    ❌ Bad (missing quotes around width/height):
+    ```xml
+    <mxGeometry x="100" y="200" width=600 height=50 as="geometry"/>
+    ```
 
 Structural Requirements:
 - You must include:
-  - <mxCell id="0"/> — the root container
-  - <mxCell id="1" parent="0"/> — the main canvas container
-- All other cells must be children of <root> with parent="1"
-- Each <mxCell> must not contain any other <mxCell> as a child
-- <mxGeometry> is the only valid child of <mxCell>
-- All attribute values in XML must be enclosed in double quotes
+  - `<mxCell id="0"/>` — the root container
+  - `<mxCell id="1" parent="0"/>` — the main canvas container
+- All other cells must be children of `<root>` with `parent="1"`
+- Each `<mxCell>` must not contain any other `<mxCell>` as a child
+- `<mxGeometry>` is the only valid child of `<mxCell>`
+- 🚫 **All attribute values must be enclosed in double quotes**, including:
+  - `x`, `y`, `width`, `height`, `as`, `id`, `value`, etc.
 
-Layout Notes:
-- Begin layout at y="100" and use consistent vertical spacing
+Style Notes:
+- 🎨 `fillColor` must appear **without quotes or escapes**:
+  ✅ Use `fillColor=#f5f5f5`  
+  ❌ Do not use `fillColor="#f5f5f5"`  
+  ❌ Do not use `fillColor=&quot;#f5f5f5&quot;`
+
+Layout Guidelines:
+- Begin layout at `y="100"` and use consistent vertical spacing
 - Place nav bars or headers above the components if applicable
-- Use logical spatial positioning without overlaps
+- Use logical spatial positioning **without overlaps**
 - You may use styling attributes like:
-  - rounded=1
-  - whiteSpace=wrap
-  - fillColor=#f5f5f5 for neutral containers
-  - fillColor=#aed581 for buttons or CTAs
-_Do NOT wrap color values in quotes or escape them. For example: Use fillColor=#f5f5f5, not fillColor=&quot;#f5f5f5&quot;._
+  - `rounded=1`
+  - `whiteSpace=wrap`
+  - `fillColor=#f5f5f5` for neutral containers
+  - `fillColor=#aed581` for buttons or CTAs
 
 Compliance Checklist:
 ✅ All XML must be well-formed  
-✅ All attributes quoted (e.g., width="600")  
-✅ No nested <mxCell> elements  
-✅ Each <mxCell> has one <mxGeometry>  
+✅ All attribute values are quoted  
+✅ No nested `<mxCell>` elements  
+✅ Each `<mxCell>` has one `<mxGeometry>`  
 ✅ Output contains XML only — no text, logs, or comments  
 
-!! Do NOT escape color values or quote them. Use: fillColor=#xxxxxx not fillColor=&quot;#xxxxxx&quot;
-!! Ensure that each component is placed far enough vertically so its full height does not overlap with the next. Use y = previous_y + previous_height + margin.
-!! Only output valid XML. All attribute values must be quoted.
-
+‼️ Do NOT escape or quote color values. Use: fillColor=#xxxxxx not fillColor=&quot;#xxxxxx&quot;  
+‼️ Ensure each component has vertical spacing (e.g., `y = previous_y + previous_height + margin`)  
+‼️ Do not output anything except valid XML. Ensure All attributes are in quotes. Use: width="xxx" height="xx" not width=xxx height=xx 

--- a/src/prompts/original_builder_prompt.txt
+++ b/src/prompts/original_builder_prompt.txt
@@ -1,0 +1,52 @@
+You are a Draw.io layout generator. Given a user interface view, output **only valid Draw.io XML**.
+
+View Name: {{view_name}}  
+View Type: {{view_type}}  
+Components: {{components}}
+
+Instructions:
+- Output must begin with <mxGraphModel> and include a single <root> element.
+- The root must contain only properly formed <mxCell> elements.
+- Do NOT include markdown, explanations, comments, or <think> tags.
+- Each component must be represented as a <mxCell> with:
+  - A unique id (e.g., id="3", id="4", etc.)
+  - vertex="1"
+  - parent="1"
+  - A value attribute equal to the component's label
+  - Exactly one <mxGeometry> child with properly quoted attributes:
+    Example:
+    <mxCell id="3" value="Submit Button" style="rounded=1;whiteSpace=wrap;fillColor=#aed581" vertex="1" parent="1">
+      <mxGeometry x="100" y="200" width="600" height="50" as="geometry"/>
+    </mxCell>
+
+Structural Requirements:
+- You must include:
+  - <mxCell id="0"/> — the root container
+  - <mxCell id="1" parent="0"/> — the main canvas container
+- All other cells must be children of <root> with parent="1"
+- Each <mxCell> must not contain any other <mxCell> as a child
+- <mxGeometry> is the only valid child of <mxCell>
+- All attribute values in XML must be enclosed in double quotes
+
+Layout Notes:
+- Begin layout at y="100" and use consistent vertical spacing
+- Place nav bars or headers above the components if applicable
+- Use logical spatial positioning without overlaps
+- You may use styling attributes like:
+  - rounded=1
+  - whiteSpace=wrap
+  - fillColor=#f5f5f5 for neutral containers
+  - fillColor=#aed581 for buttons or CTAs
+_Do NOT wrap color values in quotes or escape them. For example: Use fillColor=#f5f5f5, not fillColor=&quot;#f5f5f5&quot;._
+
+Compliance Checklist:
+✅ All XML must be well-formed  
+✅ All attributes quoted (e.g., width="600")  
+✅ No nested <mxCell> elements  
+✅ Each <mxCell> has one <mxGeometry>  
+✅ Output contains XML only — no text, logs, or comments  
+
+!! Do NOT escape color values or quote them. Use: fillColor=#xxxxxx not fillColor=&quot;#xxxxxx&quot;
+!! Ensure that each component is placed far enough vertically so its full height does not overlap with the next. Use y = previous_y + previous_height + margin.
+!! Only output valid XML. All attribute values must be quoted.
+

--- a/src/runner/pipeline.go
+++ b/src/runner/pipeline.go
@@ -65,7 +65,7 @@ func RunPipeline(yamlPath string) error {
 				}
 				attempt++
 			}
-
+			xml = shared.ForceQuoteAllAttributes(xml)
 			if err := validator.CheckLayout(xml); err != nil {
 				log.Printf("❌ Layout validation failed: %v", err)
 			} else {

--- a/src/shared/xml.go
+++ b/src/shared/xml.go
@@ -38,20 +38,20 @@ func ExtractXMLFrom(response string) string {
 
 // fixUnquotedAttributes ensures all attribute values are quoted, e.g., width=180 -> width="180"
 func fixUnquotedAttributes(xml string) string {
-	re := regexp.MustCompile(`([a-zA-Z_:]+)=([^\s>]+)`)
+	fmt.Println("🛠️ Fixing unquoted XML attributes")
 
-	return re.ReplaceAllStringFunc(xml, func(match string) string {
-		parts := strings.SplitN(match, "=", 2)
+	re := regexp.MustCompile(`\b([a-zA-Z_:]+)=([^\s"'/>]+)`)
+	return re.ReplaceAllStringFunc(xml, func(attr string) string {
+		// attr looks like: key=value
+		parts := strings.SplitN(attr, "=", 2)
 		if len(parts) != 2 {
-			return match
+			return attr // malformed, return as-is
 		}
-		attr := parts[0]
-		val := parts[1]
+		key, val := parts[0], parts[1]
 		if strings.HasPrefix(val, `"`) || strings.HasPrefix(val, `'`) {
-			// Already quoted
-			return match
+			return attr // already quoted
 		}
-		return fmt.Sprintf(`%s="%s"`, attr, val)
+		return fmt.Sprintf(`%s="%s"`, key, val)
 	})
 }
 

--- a/src/shared/xml.go
+++ b/src/shared/xml.go
@@ -1,3 +1,4 @@
+// src/shared/xml.go
 package shared
 
 import (
@@ -37,22 +38,43 @@ func ExtractXMLFrom(response string) string {
 }
 
 // fixUnquotedAttributes ensures all attribute values are quoted, e.g., width=180 -> width="180"
+// But preserves the internal structure of style attributes which contain key=value pairs
 func fixUnquotedAttributes(xml string) string {
 	fmt.Println("🛠️ Fixing unquoted XML attributes")
 
-	re := regexp.MustCompile(`\b([a-zA-Z_:]+)=([^\s"'/>]+)`)
-	return re.ReplaceAllStringFunc(xml, func(attr string) string {
-		// attr looks like: key=value
+	// Step 1: Extract and temporarily replace style attributes to protect them
+	styleRe := regexp.MustCompile(`style="[^"]*"`)
+	styles := styleRe.FindAllString(xml, -1)
+	placeholder := "@@STYLE_PLACEHOLDER@@"
+
+	// Replace all style attributes with placeholders
+	xml = styleRe.ReplaceAllString(xml, placeholder)
+
+	// Step 2: Apply the original fixing logic to everything else
+	attrRe := regexp.MustCompile(`\b([a-zA-Z_:]+)=([^\s"'=<>` + "`" + `]+)`)
+	count := 0
+
+	xml = attrRe.ReplaceAllStringFunc(xml, func(attr string) string {
 		parts := strings.SplitN(attr, "=", 2)
 		if len(parts) != 2 {
-			return attr // malformed, return as-is
+			return attr
 		}
 		key, val := parts[0], parts[1]
+		val = strings.TrimSpace(val)
 		if strings.HasPrefix(val, `"`) || strings.HasPrefix(val, `'`) {
-			return attr // already quoted
+			return attr
 		}
+		count++
 		return fmt.Sprintf(`%s="%s"`, key, val)
 	})
+
+	// Step 3: Restore the original style attributes
+	for _, style := range styles {
+		xml = strings.Replace(xml, placeholder, style, 1)
+	}
+
+	fmt.Printf("🔧 Fixed %d unquoted attribute(s)\n", count)
+	return xml
 }
 
 // escapeInvalidEntities replaces standalone & with &amp;, excluding valid XML entities
@@ -73,10 +95,15 @@ func escapeInvalidEntities(xml string) string {
 // SanitizeXML ensures all <mxGeometry> elements have required attributes.
 // Also wraps unquoted attribute values and escapes invalid ampersands.
 func SanitizeXML(raw string) (string, error) {
+	raw = ForceQuoteAllAttributes(raw)
+	fmt.Println("🧼 [SanitizeXML] ForceQuoteAllAttributes applied")
 	raw = fixUnquotedAttributes(raw)
+	raw = fixHalfQuotedAttributes(raw)
 	raw = escapeInvalidEntities(raw)
 
 	doc := etree.NewDocument()
+	// fmt.Println("📤 Sanitized XML preview:")
+	// fmt.Println(raw)
 	if err := doc.ReadFromString(raw); err != nil {
 		return "", fmt.Errorf("❌ etree failed to parse input XML: %w", err)
 	}
@@ -145,4 +172,34 @@ func DetectEscapedFillColors(raw string) ([]string, error) {
 	}
 
 	return offenders, nil
+}
+
+// ForceQuoteAllAttributes is a last-resort fix to quote any attr that looks like key=value
+func ForceQuoteAllAttributes(xml string) string {
+	re := regexp.MustCompile(`(<\w+[^>]*?)\s+([a-zA-Z_:]+)=([^\s"'/>]+)`)
+	for {
+		newXML := re.ReplaceAllString(xml, `$1 $2="$3"`)
+		if newXML == xml {
+			break
+		}
+		xml = newXML
+	}
+	return xml
+}
+
+// fixHalfQuotedAttributes detects values starting with a quote but missing the end quote
+func fixHalfQuotedAttributes(xml string) string {
+	re := regexp.MustCompile(`\b([a-zA-Z_:]+)="([^"]*?)(\s+[a-zA-Z_:]+=)`)
+	count := 0
+
+	xml = re.ReplaceAllStringFunc(xml, func(match string) string {
+		// Add missing closing quote before next attribute
+		count++
+		return regexp.MustCompile(`="([^"]*?)(\s+[a-zA-Z_:]+=)`).ReplaceAllString(match, `="$1"$2`)
+	})
+
+	if count > 0 {
+		fmt.Printf("🩹 Fixed %d half-quoted attribute(s)\n", count)
+	}
+	return xml
 }


### PR DESCRIPTION
## 🔧 Fix: Handle Half-Quoted XML Attributes in `SanitizeXML`

### Summary

This PR adds a new utility function `fixHalfQuotedAttributes()` to handle malformed attributes where the value starts with a quote but lacks a closing quote (e.g. `height="30 as="geometry"`). These previously slipped through sanitization and caused XML parsing failures.

### Changes

- Added `fixHalfQuotedAttributes()` to detect and patch half-quoted attributes.
- Integrated the fix into `SanitizeXML()` pipeline immediately after `fixUnquotedAttributes()`.

### Example Before

```xml
<mxGeometry x="100" y="100" width="200" height="30 as="geometry"/>
```

### Example After

```xml
<mxGeometry x="100" y="100" width="200" height="30" as="geometry"/>
```

### Why

This patch improves robustness in LLM-generated XML handling by preventing malformed attributes from breaking the pipeline.