### PR TITLE
Changed to the 3b param model for builder and added dedup logic in pipeline

### DIFF
--- a/src/agents/builder.go
+++ b/src/agents/builder.go
@@ -49,7 +49,7 @@ func Build(view types.ViewLayout) string {
 // callOllamaForLayout streams a completion from Ollama and returns the full text.
 func callOllamaForLayout(prompt string) (string, error) {
 	body := map[string]interface{}{
-		"model":  "qwen2.5-coder:7b-instruct-q6_K",
+		"model":  "qwen2.5-coder:3b-instruct-q8_0",
 		"prompt": prompt,
 		"options": map[string]interface{}{
 			"temperature": 0.0,


### PR DESCRIPTION
This PR updates the builder agent to use the 3b parameter model and adds filename deduplication logic in the pipeline to prevent overwriting .drawio files when multiple views share the same name. Ensures unique output filenames and preserves all generated views.