### PR TITLE
Use embed for all agent prompts

### DIFF
--- a/src/agents/auditor.go
+++ b/src/agents/auditor.go
@@ -1,8 +1,9 @@
-// src\agents\auditor.go
+// src/agents/auditor.go
 package agents
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,15 +14,17 @@ import (
 	"holoplan-cli/src/types"
 )
 
+//go:embed prompts/auditor_prompt.txt
+var auditorPrompt string
+
 // AuditResponse defines the expected JSON structure from the LLM
 type AuditResponse struct {
-	Issues []string `json:"issues"` // Array of issues or empty; "No issues" maps to empty array
+	Issues []string `json:"issues"`
 }
 
 func Audit(story types.UserStory, xml string) types.Critique {
 	prompt := buildAuditPrompt(story, xml)
 
-	// Log the full prompt for debugging
 	log.Printf("📝 Audit Prompt:\n%s\n", prompt)
 
 	response, err := callOllama(prompt)
@@ -34,49 +37,17 @@ func Audit(story types.UserStory, xml string) types.Critique {
 }
 
 func buildAuditPrompt(story types.UserStory, xml string) string {
-	return fmt.Sprintf(`
-You are a critical UI reviewer. Your task is to compare the provided user story with the layout XML and identify specific mismatches or missing elements required by the user story.
-
-**Instructions**:
-- Respond with a JSON object containing an "issues" array.
-- If there are issues, list them as strings in the format "<issue description>" (e.g., "Login button is not centered").
-- Each issue must be specific, concise, and directly tied to the user story requirements not met by the XML.
-- If the XML fully satisfies the user story, return an empty "issues" array: {"issues": []}.
-- Do **not** include validation messages, element counts, collision checks, or any text outside the JSON structure.
-- Ignore layout aesthetics unless explicitly mentioned in the user story.
-
-**Examples**:
-1. User Story: "As a user, I want a centered login button."
-   XML: "<mxGraphModel><root><mxCell id='1' value='Button' x='0' y='0'/></root></mxGraphModel>"
-   Response: {"issues": ["Login button is not centered"]}
-2. User Story: "As a user, I want a list of items."
-   XML: "<mxGraphModel><root><mxCell id='1' value='Item List' x='100' y='100' width='200' height='300'/></root></mxGraphModel>"
-   Response: {"issues": ["Item List does not indicate multiple items"]}
-3. User Story: "As a user, I want a search bar."
-   XML: "<mxGraphModel><root><mxCell id='1' value='Search Bar' x='100' y='100' width='200' height='50'/></root></mxGraphModel>"
-   Response: {"issues": []}
-
-**User Story**:
----
-%s
----
-
-**Layout XML**:
----
-%s
----
-
-**Response Format**:
-Return a JSON object: {"issues": ["<issue description>", ...]} or {"issues": []}
-`, story.Narrative, xml)
+	// fill in the embedded template instead of fmt.Sprintf inline block
+	prompt := auditorPrompt
+	prompt = strings.ReplaceAll(prompt, "{{story}}", story.Narrative)
+	prompt = strings.ReplaceAll(prompt, "{{xml}}", xml)
+	return prompt
 }
 
 func extractIssues(text string) []string {
-	// Trim whitespace for consistent comparison
 	trimmedText := strings.TrimSpace(text)
 	log.Printf("🔍 Processing LLM response (trimmed):\n%s\n", trimmedText)
 
-	// Parse JSON response
 	var auditResp AuditResponse
 	err := json.Unmarshal([]byte(trimmedText), &auditResp)
 	if err != nil {
@@ -84,7 +55,6 @@ func extractIssues(text string) []string {
 		return []string{"Malformed LLM response: invalid JSON format"}
 	}
 
-	// Log parsed issues
 	if len(auditResp.Issues) == 0 {
 		log.Printf("✅ LLM response has no issues (empty issues array)")
 		return nil
@@ -98,10 +68,10 @@ func callOllama(prompt string) (string, error) {
 	body := map[string]interface{}{
 		"model":  "llama3.1:8b",
 		"prompt": prompt,
-		"stream": false,  // Explicitly disable streaming[](https://ollama.readthedocs.io/en/api/)
-		"format": "json", // Enforce JSON output[](https://github.com/ollama/ollama/blob/main/docs/api.md?plain=1)
+		"stream": false,
+		"format": "json",
 		"options": map[string]float64{
-			"temperature": 0.0, // Lower temperature for deterministic output[](https://www.reddit.com/r/LocalLLaMA/comments/1d3x3m5/getting_llama3_to_produce_proper_json_through/)
+			"temperature": 0.0,
 		},
 	}
 	b, err := json.Marshal(body)
@@ -115,7 +85,6 @@ func callOllama(prompt string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	// Log raw HTTP response for debugging
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
@@ -131,13 +100,11 @@ func callOllama(prompt string) (string, error) {
 		return "", fmt.Errorf("failed to decode JSON response: %w", err)
 	}
 
-	// Validate response
 	if !output.Done {
 		log.Printf("🚨 Response not marked as done: %v", output)
 		return "", fmt.Errorf("incomplete LLM response")
 	}
 
-	// Log the parsed LLM response
 	log.Printf("📤 LLM Response:\n%s\n", output.Response)
 
 	return output.Response, nil

--- a/src/agents/chunker.go
+++ b/src/agents/chunker.go
@@ -1,7 +1,9 @@
+// src\agents\chunker.go
 package agents
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"holoplan-cli/src/types"
@@ -10,6 +12,9 @@ import (
 	"regexp"
 	"strings"
 )
+
+//go:embed prompts/chunker_prompt.txt
+var chunkerSystemPrompt string
 
 const ollamaURL = "http://localhost:11434/api/chat"
 
@@ -40,17 +45,7 @@ func escapeLineBreaks(input string) string {
 
 // Chunk takes a UserStory and extracts views using the LLM
 func Chunk(story types.UserStory) types.ViewPlan {
-	sysPrompt := `
-You are the StoryChunker.
-
-Given structured user story metadata, return a JSON object with:
-
-- views: an array of {name, type, components}
-- reasoning: a short explanation of how you broke the story into views
-
-Each view should include a Navbar and Footer component. Each view should include a reasonable set of UI components based on the story. Including buttons, images, etc. Components should be descriptive nouns or short phrases.
-
-Respond ONLY with a raw JSON object. Do not include explanations, markdown, tags, or commentary.`
+	sysPrompt := chunkerSystemPrompt
 
 	userPrompt := fmt.Sprintf(`User Story:
 

--- a/src/agents/prompts/auditor_prompt.txt
+++ b/src/agents/prompts/auditor_prompt.txt
@@ -1,0 +1,33 @@
+You are a critical UI reviewer. Your task is to compare the provided user story with the layout XML and identify specific mismatches or missing elements required by the user story.
+
+**Instructions**:
+- Respond with a JSON object containing an "issues" array.
+- If there are issues, list them as strings in the format "<issue description>" (e.g., "Login button is not centered").
+- Each issue must be specific, concise, and directly tied to the user story requirements not met by the XML.
+- If the XML fully satisfies the user story, return an empty "issues" array: {"issues": []}.
+- Do **not** include validation messages, element counts, collision checks, or any text outside the JSON structure.
+- Ignore layout aesthetics unless explicitly mentioned in the user story.
+
+**Examples**:
+1. User Story: "As a user, I want a centered login button."
+   XML: "<mxGraphModel><root><mxCell id='1' value='Button' x='0' y='0'/></root></mxGraphModel>"
+   Response: {"issues": ["Login button is not centered"]}
+2. User Story: "As a user, I want a list of items."
+   XML: "<mxGraphModel><root><mxCell id='1' value='Item List' x='100' y='100' width='200' height='300'/></root></mxGraphModel>"
+   Response: {"issues": ["Item List does not indicate multiple items"]}
+3. User Story: "As a user, I want a search bar."
+   XML: "<mxGraphModel><root><mxCell id='1' value='Search Bar' x='100' y='100' width='200' height='50'/></root></mxGraphModel>"
+   Response: {"issues": []}
+
+**User Story**:
+---
+{{story}}
+---
+
+**Layout XML**:
+---
+{{xml}}
+---
+
+**Response Format**:
+Return a JSON object: {"issues": ["<issue description>", ...]} or {"issues": []}

--- a/src/agents/prompts/chunker_prompt.txt
+++ b/src/agents/prompts/chunker_prompt.txt
@@ -1,0 +1,10 @@
+You are the StoryChunker.
+
+Given structured user story metadata, return a JSON object with:
+
+- views: an array of {name, type, components}
+- reasoning: a short explanation of how you broke the story into views
+
+Each view should include a Navbar and Footer component. Each view should include a reasonable set of UI components based on the story. Including buttons, images, etc. Components should be descriptive nouns or short phrases.
+
+Respond ONLY with a raw JSON object. Do not include explanations, markdown, tags, or commentary.

--- a/src/agents/prompts/resolver_prompt.txt
+++ b/src/agents/prompts/resolver_prompt.txt
@@ -12,4 +12,7 @@ Here is the user story for context:
 Here is the original layout:
 {{xml}}
 
-Return only the corrected XML. Do not include explanations or extra text.
+Return only the corrected Draw.io layout XML.  
+Do not include explanations, markdown, or JSON wrappers.  
+Do not escape characters or add quotes.  
+Only output valid <mxGraphModel> XML.


### PR DESCRIPTION
This PR updates all relevant agents to use `//go:embed` for their prompt templates. Prompts for the resolver, auditor, and chunker have been moved into the `src/agents/prompts/` directory and embedded at compile time. This allows cleaner code separation, easier versioning of prompts, and simpler testing workflows. Also includes adjustments to log raw LLM responses and use plain text instead of JSON where appropriate.