### PR TITLE
Handle overzealous resolver behavior

### DIFF
--- a/scripts/empty_output.sh
+++ b/scripts/empty_output.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 OUTPUT_DIR="output"
 
-echo "Deleting all .drawio and .drawio.xml files in the '$OUTPUT_DIR' directory..."
+echo "Deleting all .drawio, .drawio.xml, and .txt files in the '$OUTPUT_DIR' directory..."
 
 if [ ! -d "$OUTPUT_DIR" ]; then
   echo "Directory '$OUTPUT_DIR' does not exist. Nothing to clean."
@@ -13,7 +13,7 @@ if [ ! -d "$OUTPUT_DIR" ]; then
 fi
 
 shopt -s nullglob
-FILES=("$OUTPUT_DIR"/*.drawio "$OUTPUT_DIR"/*.drawio.xml)
+FILES=("$OUTPUT_DIR"/*.drawio "$OUTPUT_DIR"/*.drawio.xml "$OUTPUT_DIR"/*.txt)
 shopt -u nullglob
 
 if [ ${#FILES[@]} -eq 0 ]; then

--- a/src/agents/auditor.go
+++ b/src/agents/auditor.go
@@ -89,7 +89,7 @@ func callOllama(prompt string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
-	log.Printf("📥 Raw Ollama Response:\n%s\n", string(bodyBytes))
+	// log.Printf("📥 Raw Ollama Response:\n%s\n", string(bodyBytes))
 
 	var output struct {
 		Response string `json:"response"`


### PR DESCRIPTION
This PR updates the pipeline to only audit the initially built XML and perform a single correction attempt via the resolver. It avoids repeated auditing loops which caused excessive corrections based on subjective critiques. Ensures spatial layout is still validated after correction.